### PR TITLE
Prevent postfix from being restarted on every chef run.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "info@room118solutions.com"
 license          "Apache 2.0"
 description      "Installs/Configures postfix and opendkim, a postfix DKIM filter (see: https://help.ubuntu.com/community/Postfix/DKIM)"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.6"
+version          "1.1.0"
 depends          'postfix', '> 3.0.0'
 issues_url       "https://github.com/room118solutions/chef-postfix-dkim/issues"
 source_url       "https://github.com/room118solutions/chef-postfix-dkim"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,7 +63,3 @@ end
 service "opendkim" do
   action :start
 end
-
-service "postfix" do
-  action :restart
-end


### PR DESCRIPTION
Hi,

The service resource I've removed here doesn't seem to serve any direct purpose, other than forcing a postfix restart every time chef runs. The attributes earlier in the recipe should cause updates to the postfix config, but the postfix cookbook itself has a notification to reload postfix when those change, so this is redundant.

Removing this can help with performance problems - it takes postfix a little while to spin up all its workers again, and while its doing that it might refuse connections from clients - and makes the cookbook a little cleaner.

Thanks,

John.
